### PR TITLE
AWS Glue compatibility - only use named args

### DIFF
--- a/pyspark_framework/examples/README.md
+++ b/pyspark_framework/examples/README.md
@@ -13,7 +13,7 @@ python driver.py \
 
 ```bash
 python -m pyspark_framework.spark_run \
-          pyspark_framework.examples.example_job.FlightSummary \
+          --class pyspark_framework.examples.example_job.FlightSummary \
           --input pyspark_framework/examples/example_data/flight-data/csv \
           --output=/tmp/spark/tests
 ```
@@ -21,7 +21,7 @@ python -m pyspark_framework.spark_run \
 ...or if you prefer you can use the console script:
 
 ```bash
-spark-run pyspark_framework.examples.example_job.FlightSummary \
+spark-run --class pyspark_framework.examples.example_job.FlightSummary \
           --input pyspark_framework/examples/example_data/flight-data/csv \
           --output=/tmp/spark/tests          
 ```

--- a/pyspark_framework/spark_run.py
+++ b/pyspark_framework/spark_run.py
@@ -10,6 +10,7 @@ This module provides an easy method of running a Spark job by just supplying
 the module and class reference. The arguments are derived from sys.argv.
 """
 
+
 def main():
     """
     Main entry point for running a Spark job
@@ -36,9 +37,11 @@ def get_args(args):
     """
 
     argp = argparse.ArgumentParser(prog='Spark Job Runner')
-    argp.add_argument('job_class_name',
+    argp.add_argument('--class',
                       help='Fully qualified job class '
-                           'e.g. package.module.ClassName')
+                           'e.g. package.module.ClassName',
+                      dest="job_class_name",
+                      required=True)
     argp.add_argument('--app-name', '-a', default='pyspark-job',
                       help='Application name to send to Spark Session')
     argp.add_argument('--s3', action='store_true',


### PR DESCRIPTION
AWS Glue only understands named arguments, so this breaks the nice positional argument we have for the job class. Reluctantly converting this to a named argument.